### PR TITLE
PrgCode section name

### DIFF
--- a/link.x
+++ b/link.x
@@ -1,7 +1,16 @@
 SECTIONS {
     . = 0x0;
 
-    .text : {
+    /*
+     * The PrgCode output section name comes from the CMSIS-Pack flash algo
+     * templates and armlink. It is used here because several tools that work
+     * with these flash algos expect this section name.
+     *
+     * All input sections are combined into PrgCode because RWPI using R9 is not
+     * currently stable in Rust, thus having separate PrgData sections that the
+     * debug host might locate at a different offset from PrgCode is not safe.
+     */
+    PrgCode : {
         KEEP(*(.entry))
         KEEP(*(.entry.*))
 


### PR DESCRIPTION
Separate sections for read-only and read-write are needed by pyocd's conversion script and generally good to have split out since the ELF section attributes are quite different. These section names match the names used in Keil µVision generated FLM files, and thus are more compatible. (Otherwise, I'd have used the standard names; I'm not particularly fond of `PrgCode` and `PrgData`.)

And yes, there are two `PrgData` sections, but with different ELF attributes.