### PR TITLE
build: Fix grep to search only the exact symbol name

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ function bin {
 }
 
 function sym {
-    echo $((0x$(llvm-nm $ELF | grep $1 | cut -d ' ' -f 1) + 1))
+    echo $((0x$(llvm-nm $ELF | grep -w $1 | cut -d ' ' -f 1) + 1))
 }
 
 cat <<EOF


### PR DESCRIPTION
For example Init and UnInit conflict with each other.