### PR TITLE
Don't set _IS_INIT = true before initializing _ALGO_INSTANCE

### DIFF
--- a/src/algo.rs
+++ b/src/algo.rs
@@ -44,7 +44,6 @@ macro_rules! algo {
             if _IS_INIT {
                 UnInit();
             }
-            _IS_INIT = true;
             match <$type as FlashAlgo>::new(addr, clock, function) {
                 Ok(inst) => {
                     _ALGO_INSTANCE.as_mut_ptr().write(inst);


### PR DESCRIPTION
I hope I don't miss any subtle detail, but it looks wrong to set _IS_INIT before _ALGO_INSTANCE gets initialized. In case new returns Err, _ALGO_INSTANCE will stay uninitialized, but a later call to UnInit will still try to drop it.

As there is already a _IS_INIT = true immediately after setting _ALGO_INSTANCE, I think this line can just be removed.