### PR TITLE
Fix build

### DIFF
--- a/src/algo.rs
+++ b/src/algo.rs
@@ -1,6 +1,7 @@
 #![macro_use]
 
 
+use core::arch::asm;
 use core::num::NonZeroU32;
 
 #[panic_handler]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![no_main]
-#![feature(asm)]
 
 mod algo;
 


### PR DESCRIPTION
Fixes this compile error:
```
error: cannot find macro `asm` in this scope
 --> src/algo.rs:9:9
  |
9 |         asm!("udf #0");
  |         ^^^
  |
  = help: consider importing this macro:
          core::arch::asm

warning: the feature `asm` has been stable since 1.59.0 and no longer requires an attribute to enable
 --> src/main.rs:3:12
  |
3 | #![feature(asm)]
  |            ^^^
  |
  = note: `#[warn(stable_features)]` on by default

warning: `flash-algo` (bin "flash-algo") generated 1 warning
error: could not compile `flash-algo` (bin "flash-algo") due to previous error; 1 warning emitted
```