### PR TITLE
Now builds on stable.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,7 +1,3 @@
-[unstable]
-build-std = ["core"]
-build-std-features = ["panic_immediate_abort"]
-
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 
 rustflags = [
@@ -9,7 +5,6 @@ rustflags = [
   "-C", "link-arg=-Tlink.x",
 
   # Code-size optimizations.
-  "-Z", "trap-unreachable=no",
   "-C", "inline-threshold=5",
   "-C", "no-vectorize-loops",
   "-C", "force-frame-pointers=no",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,12 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Install Dependencies
       run: |
-        sudo apt update
-        rustup component add rust-src
         cargo install cargo-binutils
-        rustup component add llvm-tools-preview
     - name: Build
       run: |
         ./build.sh

--- a/README.md
+++ b/README.md
@@ -5,23 +5,27 @@ It implements the CMSIS-Pack ABI, so it's compatible with any tools that use it,
 
 ## Dependencies
 
-Run the following requirements:
-```bash
-cargo install cargo-binutils && rustup component add llvm-tools-preview rust-src
-```
-## Building
+Run the following to install the requirements:
 
-Building requires nightly Rust.
+```bash
+cargo install cargo-binutils
+```
+
+The `rust-toolchain` file will get you the targets and components you need.
+
+## Building
 
 Just run `build.sh`. It spits out the flash algo in the probe-rs YAML format:
 
-    flash-algo$ ./build.sh 
+```console
+flash-algo$ ./build.sh 
     instructions: sLUUIACIGUoBRguI...wRwAgcEc=
     pc_init: 0x00000000
     pc_uninit: 0x0000007c
     pc_program_page: 0x00000088
     pc_erase_sector: 0x00000084
     pc_erase_all: 0x00000080
+```
 
 ## Hacking
 
@@ -30,7 +34,7 @@ the glue functions for a given struct implementing it. This is generic for all c
 
 `main.rs` has the actual implementation for RP2040.
 
-# License
+## License
 
 This thingy is licensed under either of
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,5 @@
-nightly
+[toolchain]
+channel = "stable"
+components = [ "llvm-tools" ]
+profile = "minimal"
+targets = ["thumbv6m-none-eabi"]

--- a/src/algo.rs
+++ b/src/algo.rs
@@ -1,6 +1,5 @@
 #![macro_use]
 
-
 use core::arch::asm;
 use core::num::NonZeroU32;
 
@@ -11,10 +10,6 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
         core::hint::unreachable_unchecked();
     }
 }
-
-pub const FUNCTION_ERASE: u32 = 1;
-pub const FUNCTION_PROGRAM: u32 = 2;
-pub const FUNCTION_VERIFY: u32 = 3;
 
 pub type ErrorCode = NonZeroU32;
 


### PR DESCRIPTION
Tested working with probe-rs CLI. Slightly larger binary, but I can live with that for not having to use nightly rust.

```console
$ ./build.sh
    Finished release [optimized + debuginfo] target(s) in 0.10s
    instructions: 8LUDr4mwK0x8RCB4ASgqTX1EKk5+RAPRKGiARzBogEcBIAiQIHAGlRglKogHlBQkIIgFlhtOMUb3MZBHBJAqiCCIGUmJHJBHA5AqiCCIMUaQRwKQKoggiBRJkEcBkCqIIIgTSZBHBkYqiCCIDkmQRwVGBJygRwOYgEcRSHhEApkBYBBIeEQEYA9IeEQBmQFgBpgGYAWYBWAImAeZCHAAIAmw8L1SRQAAQ1gAAFJQAABGQwAAeAEAAIABAACAAQAADAEAAAABAAACAQAA0LUCrwhMfEQgeAEoCtEHSHhEAGiARwZIeEQAaIBHACAgcNC9ASDQva4AAAC0AAAAsAAAAAVIeEQAeAAoAdEBIHBHAUhwR8BG0HAAAH4AAADQtQKvCUl5RAl4ASkM0Q8hCQdAGAZJeUQMaAEiEQMSBNgjoEcAINC9ASDQvV4AAABWAAAA0LUCrwtGCUl5RAl4ASkK0Q8hCQdAGAZJeUQMaBFGGkagRwAg0L0BINC9wEYoAAAAJAAAAADU1NQAAAAAAAAAAAAAAAAAAAAAAAAAAA==
    pc_init: 1
    pc_uninit: 205
    pc_program_page: 337
    pc_erase_sector: 285
    pc_erase_all: 257
```

It also uses the official ROM function for walking the ROM table entries rather than walking them manually.