### PR TITLE
Add cmd to erase multiple sectors

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,6 +30,6 @@ cat <<EOF
     pc_uninit: $(sym UnInit)
     pc_program_page: $(sym ProgramPage)
     pc_erase_sector: $(sym EraseSector)
-    pc_erase_sectors: $(sym EraseSectors)
+    pc_erase_range: $(sym EraseRange)
     pc_erase_all: $(sym EraseChip)
 EOF

--- a/build.sh
+++ b/build.sh
@@ -30,5 +30,6 @@ cat <<EOF
     pc_uninit: $(sym UnInit)
     pc_program_page: $(sym ProgramPage)
     pc_erase_sector: $(sym EraseSector)
+    pc_erase_sectors: $(sym EraseSectors)
     pc_erase_all: $(sym EraseChip)
 EOF

--- a/src/algo.rs
+++ b/src/algo.rs
@@ -23,8 +23,8 @@ pub trait FlashAlgo: Sized + 'static {
     /// Erase sector. May only be called after init() with FUNCTION_ERASE
     fn erase_sector(&mut self, addr: u32) -> Result<(), ErrorCode>;
 
-    /// Erase a number of sectors. May only be called after init() with FUNCTION_ERASE
-    fn erase_sectors(&mut self, addr: u32, qty: u32) -> Result<(), ErrorCode>;
+    /// Erase a range of memory. May only be called after init() with FUNCTION_ERASE
+    fn erase_range(&mut self, start_addr: u32, end_addr: u32) -> Result<(), ErrorCode>;
 
     /// Program bytes. May only be called after init() with FUNCTION_PROGRAM
     fn program_page(&mut self, addr: u32, size: u32, data: *const u8) -> Result<(), ErrorCode>;
@@ -105,20 +105,21 @@ macro_rules! algo {
                 Err(e) => e.get(),
             }
         }
-        /// Erase a number of sectors on the flash chip.
-        /// Will use block erase commands when possible to improve performance
+        /// Erase a range of memory on the flash chip.
+        /// Algo can use page/block erase commands to improve performance vs EraseSector
         ///
         /// # Safety
         ///
-        /// Will erase the given sectors. Pass a valid sector address and valid range of sectors.
+        /// Will erase all memory inside the address range.
+        /// Must pass a valid sector start and end address.
         #[no_mangle]
         #[link_section = ".entry"]
-        pub unsafe extern "C" fn EraseSectors(addr: u32, qty: u32) -> u32 {
+        pub unsafe extern "C" fn EraseRange(start_addr: u32, end_addr: u32) -> u32 {
             if !_IS_INIT {
                 return 1;
             }
             let this = &mut *_ALGO_INSTANCE.as_mut_ptr();
-            match <$type as FlashAlgo>::erase_sectors(this, addr, qty) {
+            match <$type as FlashAlgo>::erase_range(this, start_addr, end_addr) {
                 Ok(()) => 0,
                 Err(e) => e.get(),
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,9 +80,14 @@ impl FlashAlgo for RP2040Algo {
         Ok(())
     }
 
-    fn erase_sectors(&mut self, addr: u32, qty: u32) -> Result<(), ErrorCode> {
-        let erase_size = SECTOR_SIZE * qty;
-        (self.funcs.flash_range_erase)(addr - FLASH_BASE, erase_size, BLOCK_SIZE, BLOCK_ERASE_CMD);
+    fn erase_range(&mut self, start_addr: u32, end_addr: u32) -> Result<(), ErrorCode> {
+        let erase_size = end_addr - start_addr;
+        (self.funcs.flash_range_erase)(
+            start_addr - FLASH_BASE,
+            erase_size,
+            BLOCK_SIZE,
+            BLOCK_ERASE_CMD,
+        );
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,12 @@ impl FlashAlgo for RP2040Algo {
         Ok(())
     }
 
+    fn erase_sectors(&mut self, addr: u32, qty: u32) -> Result<(), ErrorCode> {
+        let erase_size = SECTOR_SIZE * qty;
+        (self.funcs.flash_range_erase)(addr - FLASH_BASE, erase_size, BLOCK_SIZE, BLOCK_ERASE_CMD);
+        Ok(())
+    }
+
     fn program_page(&mut self, addr: u32, size: u32, data: *const u8) -> Result<(), ErrorCode> {
         (self.funcs.flash_range_program)(addr - FLASH_BASE, data, size);
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,13 +81,8 @@ impl FlashAlgo for RP2040Algo {
     }
 
     fn erase_range(&mut self, start_addr: u32, end_addr: u32) -> Result<(), ErrorCode> {
-        let erase_size = end_addr - start_addr;
-        (self.funcs.flash_range_erase)(
-            start_addr - FLASH_BASE,
-            erase_size,
-            BLOCK_SIZE,
-            BLOCK_ERASE_CMD,
-        );
+        let size = (end_addr - start_addr) + 1;
+        (self.funcs.flash_range_erase)(start_addr - FLASH_BASE, size, BLOCK_SIZE, BLOCK_ERASE_CMD);
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,8 +81,12 @@ impl FlashAlgo for RP2040Algo {
     }
 
     fn erase_range(&mut self, start_addr: u32, end_addr: u32) -> Result<(), ErrorCode> {
-        let size = (end_addr - start_addr) + 1;
-        (self.funcs.flash_range_erase)(start_addr - FLASH_BASE, size, BLOCK_SIZE, BLOCK_ERASE_CMD);
+        (self.funcs.flash_range_erase)(
+            start_addr - FLASH_BASE,
+            end_addr - start_addr,
+            BLOCK_SIZE,
+            BLOCK_ERASE_CMD,
+        );
         Ok(())
     }
 


### PR DESCRIPTION
On fast debug probes, erasing is the slowest operation during flash.
Add a function to the algo to pass a range of sectors to erase so that allow flash_range_erase can use block erase commands to perform the erase.
This is a bit more than 2x faster than sector erase.

Requires https://github.com/probe-rs/probe-rs/pull/2132

Will rebase onto main once #19 is merged.