### PR TITLE
Add feature to preserve cmsis-pack metadata in output elf

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -2,7 +2,7 @@
 
 rustflags = [
   "-C", "link-arg=--nmagic",
-  "-C", "link-arg=-Tlink.x",
+  "-C", "link-arg=-Tlink_real.x",
 
   # Code-size optimizations.
   "-C", "inline-threshold=5",

--- a/.cargo/config
+++ b/.cargo/config
@@ -2,7 +2,7 @@
 
 rustflags = [
   "-C", "link-arg=--nmagic",
-  "-C", "link-arg=-Tlink_real.x",
+  "-C", "link-arg=-Tlink_generated.x",
 
   # Code-size optimizations.
   "-C", "inline-threshold=5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ flash-algorithm = { version = "0.4.0", default-features = false, features = [
     "panic-handler",
 ] }
 
+[features]
+# Keep extra metadata in the final binary that probe-rs doesn't strictly need.
+# Other tools use of these datastructures: probe-rs' target-gen, pyocd, jlink
+cmsis-pack-compat = []
+
 # this lets you use `cargo fix`!
 [[bin]]
 name = "flash-algo"

--- a/build.rs
+++ b/build.rs
@@ -1,21 +1,41 @@
 use std::env;
 use std::fs::File;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 fn main() {
     // Put `link.x` in our output directory and ensure it's
     // on the linker search path.
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-    File::create(out.join("link.x"))
+
+    println!("cargo:rustc-link-search={}", out.display());
+
+    // Call another function to copy the linker script into the output directory.
+    // This allows us to use a different linker script based on whether the
+    // cmsis-pack-compat feature is enabled or not
+    setup_linker_script(out);
+}
+
+#[cfg(not(feature = "cmsis-pack-compat"))]
+fn setup_linker_script(out: &Path) {
+    // rename the linker output to ensure we use the one in the
+    // build output instead of the one in the project root
+    File::create(out.join("link_output.x"))
         .unwrap()
         .write_all(include_bytes!("link.x"))
         .unwrap();
-    println!("cargo:rustc-link-search={}", out.display());
-
     // By default, Cargo will re-run a build script whenever
     // any file in the project changes. By specifying `link.x`
     // here, we ensure the build script is only re-run when
     // `link.x` is changed.
     println!("cargo:rerun-if-changed=link.x");
+}
+
+#[cfg(feature = "cmsis-pack-compat")]
+fn setup_linker_script(out: &Path) {
+    File::create(out.join("link_output.x"))
+        .unwrap()
+        .write_all(include_bytes!("link_metadata.x"))
+        .unwrap();
+    println!("cargo:rerun-if-changed=link_metadata.x");
 }

--- a/build.rs
+++ b/build.rs
@@ -20,7 +20,7 @@ fn main() {
 fn setup_linker_script(out: &Path) {
     // rename the linker output to ensure we use the one in the
     // build output instead of the one in the project root
-    File::create(out.join("link_output.x"))
+    File::create(out.join("link_generated.x"))
         .unwrap()
         .write_all(include_bytes!("link.x"))
         .unwrap();
@@ -33,7 +33,7 @@ fn setup_linker_script(out: &Path) {
 
 #[cfg(feature = "cmsis-pack-compat")]
 fn setup_linker_script(out: &Path) {
-    File::create(out.join("link_output.x"))
+    File::create(out.join("link_generated.x"))
         .unwrap()
         .write_all(include_bytes!("link_metadata.x"))
         .unwrap();

--- a/build_w_metadata.sh
+++ b/build_w_metadata.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# macOS base64 doesn't take -w argument and defaults to a single line.
+if [[ $(uname) = "Darwin" ]]; then
+    BASE64_FLAGS=""
+else
+    BASE64_FLAGS="-w0"
+fi
+
+cargo build --release --features cmsis-pack-compat
+ELF=target/thumbv6m-none-eabi/release/flash-algo
+
+rust-objdump --disassemble $ELF > target/disassembly.s
+rust-objdump -x $ELF > target/dump.txt
+rust-nm $ELF -n > target/nm.txt
+
+function bin {
+    rust-objcopy $ELF -O binary - | base64 $BASE64_FLAGS
+}
+
+function sym {
+    echo $((0x$(rust-nm $ELF | grep -w $1 | cut -d ' ' -f 1) + 1))
+}
+
+cat <<EOF
+    instructions: $(bin)
+    pc_init: $(sym Init)
+    pc_uninit: $(sym UnInit)
+    pc_program_page: $(sym ProgramPage)
+    pc_erase_sector: $(sym EraseSector)
+EOF

--- a/link_metadata.x
+++ b/link_metadata.x
@@ -1,0 +1,70 @@
+SECTIONS {
+    . = 0x0;
+
+    /*
+     * The PrgCode output section name comes from the CMSIS-Pack flash algo
+     * templates and armlink. It is used here because several tools that work
+     * with these flash algos expect this section name.
+     *
+     * All input sections are combined into PrgCode because RWPI using R9 is not
+     * currently stable in Rust, thus having separate PrgData sections that the
+     * debug host might locate at a different offset from PrgCode is not safe.
+     */
+    PrgCode : {
+        KEEP(*(.entry))
+        KEEP(*(.entry.*))
+
+        *(.text)
+        *(.text.*)
+
+        *(.rodata)
+        *(.rodata.*)
+
+        *(.data)
+        *(.data.*)
+
+        *(.sdata)
+        *(.sdata.*)
+        
+        *(.bss)
+        *(.bss.*)
+
+        *(.uninit)
+        *(.uninit.*)
+
+        . = ALIGN(4);
+    }
+
+    /* Section for data, specified by flashloader standard. */
+    PrgData : {
+      /*
+       * We're explicitly putting a single object here (PRGDATA_Start in main.c) as this is required by some tools.
+       * It is not used by this algorithm
+       *
+       * The KEEP statement ensures it's not removed by accident.
+       */
+        KEEP(*(PrgData))
+
+        . = ALIGN(4);
+    }
+
+    /* Description of the flash algorithm */
+    DevDscr . : {
+        /* The device data content is only for external tools,
+         * and usually not referenced by the code.
+         * All rules have exceptions: device data is used by this flash algo.
+         *
+         * The KEEP statement ensures it's not removed by accident.
+         */
+        KEEP(*(DeviceData))
+
+        . = ALIGN(4);
+    }
+
+    /DISCARD/ : {
+        /* Unused exception related info that only wastes space */
+        *(.ARM.exidx);
+        *(.ARM.exidx.*);
+        *(.ARM.extab.*);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,3 +100,14 @@ impl Drop for RP2040Algo {
         (self.funcs.flash_enter_cmd_xip)();
     }
 }
+
+/// Some tools (eg Segger's debugger) require the PrgData section to exist in the target binary
+///
+/// They scan the flashloader binary for this symbol to determine the section location
+/// If they cannot find it, the tool exits. This variable serves no other purpose
+#[allow(non_upper_case_globals)]
+#[no_mangle]
+#[used]
+#[link_section = "PrgData"]
+#[cfg(feature = "cmsis-pack-compat")]
+pub static mut PRGDATA_Start: usize = 0;


### PR DESCRIPTION
The current linker script doesn't preserve all sections required for the output binary to be properly compatible with other tools following the cmsis-pack standard.
Add a feature "cmsis-pack-compat" that preserves these sections.

Note: this does cause the binary to become larger, otherwise I would have just replaced the existing linker script.

Untested with Segger's tooling at the moment.
Flash algorithms extracted with probe-rs' target-gen and pyocd's generate-blobs.py, but also untested.

This PR should accomplish everything #14 did.
It will remain a draft until testing has validated that everything is functional.

**Original**
```console
$ ./build.sh 
   Compiling flash-algo v0.1.0 (/home/nine/vc/rust/flash-algo)
    Finished release [optimized + debuginfo] target(s) in 0.16s
    instructions: 8LUDr4ewFUY1THxEIHgBKAfRNEh4RABogEczSHhEAGiARwEgBpAFlCBwaB4DKE3SFCUoiBgkIoglTjFG9zGQRwAoQNAEkCiIIogiSYkckEcAKDjQA5AoiCKIMUaQRwAoMdAGRiiIIogbSZBHACgq0AKQKIgiiBlJkEcAKCPQAJABliiIIogTSZBHACgb0AZGBJygRwOYgEcUSHhEAZkBYBNIeEQEYBNIeEQCmQFgEkh4RACZAWARSHhEBmAGmAWZCHAAIADgBpgHsPC9APBm+FJFAABDWAAAUlAAAEZDAACWAQAAnAEAAJgBAAAOAQAAAgEAAAQBAAAAAQAA/AAAANC1Aq8ITHxEIHgBKArRB0h4RABogEcGSHhEAGiARwAgIHDQvQEg0L2aAAAAoAAAAJwAAADQtQKvCUl5RAl4ASkM0Q8hCQdAGAZJeUQMaAEiEQMSBNgjoEcAINC9ASDQvWYAAABeAAAA0LUCrwtGCUl5RAl4ASkK0Q8hCQdAGAZJeUQMaBFGGkagRwAg0L0BINC9wEYwAAAALAAAAIC1AK8A3v7eANTU1AAAAAAAAAAAAAAAAAAAAAAAAAAA
    pc_init: 1
    pc_uninit: 257
    pc_program_page: 361
    pc_erase_sector: 309
    
$ arm-none-eabi-size target/thumbv6m-none-eabi/release/flash-algo
   text    data     bss     dec     hex filename
    444       0       0     444     1bc target/thumbv6m-none-eabi/release/flash-algo

$ arm-none-eabi-readelf --demangle=rust -s target/thumbv6m-none-eabi/release/flash-algo
Symbol table '.symtab' contains 22 entries:
   Num:    Value  Size Type    Bind   Vis      Ndx Name
     0: 00000000     0 NOTYPE  LOCAL  DEFAULT  UND 
     1: 00000000     0 FILE    LOCAL  DEFAULT  ABS flash_algo.a1fe4[...]
     2: 00000000     0 NOTYPE  LOCAL  DEFAULT    1 $t.0
     3: 0000019d     8 FUNC    LOCAL  DEFAULT    1 core::panicking:[...]
     4: 000000d0     0 NOTYPE  LOCAL  DEFAULT    1 $d.1
     5: 000001a4     1 OBJECT  LOCAL  DEFAULT    1 flash_algo::_IS_[...]
     6: 000001b4     4 OBJECT  LOCAL  DEFAULT    1 flash_algo::_ALG[...]
     7: 000001b8     4 OBJECT  LOCAL  DEFAULT    1 flash_algo::_ALG[...]
     8: 000001ac     4 OBJECT  LOCAL  DEFAULT    1 flash_algo::_ALG[...]
     9: 000001a8     4 OBJECT  LOCAL  DEFAULT    1 flash_algo::_ALG[...]
    10: 000001b0     4 OBJECT  LOCAL  DEFAULT    1 flash_algo::_ALG[...]
    11: 00000100     0 NOTYPE  LOCAL  DEFAULT    1 $t.2
    12: 00000128     0 NOTYPE  LOCAL  DEFAULT    1 $d.3
    13: 00000134     0 NOTYPE  LOCAL  DEFAULT    1 $t.4
    14: 00000160     0 NOTYPE  LOCAL  DEFAULT    1 $d.5
    15: 00000168     0 NOTYPE  LOCAL  DEFAULT    1 $t.6
    16: 00000194     0 NOTYPE  LOCAL  DEFAULT    1 $d.7
    17: 0000019c     0 NOTYPE  LOCAL  DEFAULT    1 $t.8
    18: 00000135    52 FUNC    GLOBAL DEFAULT    1 EraseSector
    19: 00000001   256 FUNC    GLOBAL DEFAULT    1 Init
    20: 00000169    52 FUNC    GLOBAL DEFAULT    1 ProgramPage
    21: 00000101    52 FUNC    GLOBAL DEFAULT    1 UnInit

$ arm-none-eabi-objdump -h target/thumbv6m-none-eabi/release/flash-algo
target/thumbv6m-none-eabi/release/flash-algo:     file format elf32-littlearm

Sections:
Idx Name          Size      VMA       LMA       File off  Algn
  0 PrgCode       000001bc  00000000  00000000  00000074  2**2
                  CONTENTS, ALLOC, LOAD, CODE
  1 .debug_loc    00000360  00000000  00000000  00000230  2**0
                  CONTENTS, READONLY, DEBUGGING, OCTETS
  2 .debug_abbrev 0000034b  00000000  00000000  00000590  2**0
                  CONTENTS, READONLY, DEBUGGING, OCTETS
  3 .debug_info   000016c2  00000000  00000000  000008db  2**0
                  CONTENTS, READONLY, DEBUGGING, OCTETS
  4 .debug_aranges 00000078  00000000  00000000  00001f9d  2**0
                  CONTENTS, READONLY, DEBUGGING, OCTETS
  5 .debug_str    000010ee  00000000  00000000  00002015  2**0
                  CONTENTS, READONLY, DEBUGGING, OCTETS
  6 .comment      00000040  00000000  00000000  00003103  2**0
                  CONTENTS, READONLY
  7 .ARM.attributes 00000034  00000000  00000000  00003143  2**0
                  CONTENTS, READONLY
  8 .debug_frame  000000b4  00000000  00000000  00003178  2**2
                  CONTENTS, READONLY, DEBUGGING, OCTETS
  9 .debug_line   00000456  00000000  00000000  0000322c  2**0
                  CONTENTS, READONLY, DEBUGGING, OCTETS
```

**With `cmsis-pack-compat` feature enabled**
```console
$ ./build_w_metadata.sh 
   Compiling flash-algo v0.1.0 (/home/nine/vc/rust/flash-algo)
    Finished release [optimized + debuginfo] target(s) in 0.24s
    instructions: 8LUDr4ewFUY1THxEIHgBKAfRNEh4RABogEczSHhEAGiARwEgBpAFlCBwaB4DKE3SFCUoiBgkIoglTjFG9zGQRwAoQNAEkCiIIogiSYkckEcAKDjQA5AoiCKIMUaQRwAoMdAGRiiIIogbSZBHACgq0AKQKIgiiBlJkEcAKCPQAJABliiIIogTSZBHACgb0AZGBJygRwOYgEcUSHhEAZkBYBNIeEQEYBNIeEQCmQFgEkh4RACZAWARSHhEBmAGmAWZCHAAIADgBpgHsPC9APBm+FJFAABDWAAAUlAAAEZDAACWAQAAnAEAAJgBAAAOAQAAAgEAAAQBAAAAAQAA/AAAANC1Aq8ITHxEIHgBKArRB0h4RABogEcGSHhEAGiARwAgIHDQvQEg0L2aAAAAoAAAAJwAAADQtQKvCUl5RAl4ASkM0Q8hCQdAGAZJeUQMaAEiEQMSBNgjoEcAINC9ASDQvWYAAABeAAAA0LUCrwtGCUl5RAl4ASkK0Q8hCQdAGAZJeUQMaBFGGkagRwAg0L0BINC9wEYwAAAALAAAAIC1AK8A3v7eANTU1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAABAAAAABAAEAAAAAAAD/AAAA6AMAANAHAAAAEAAAAAAAEP//////////
    pc_init: 1
    pc_uninit: 257
    pc_program_page: 361
    pc_erase_sector: 309
    
$ arm-none-eabi-size target/thumbv6m-none-eabi/release/flash-algo
   text    data     bss     dec     hex filename
    620       4       0     624     270 target/thumbv6m-none-eabi/release/flash-algo    

$ arm-none-eabi-objdump -h target/thumbv6m-none-eabi/release/flash-algo 
target/thumbv6m-none-eabi/release/flash-algo:     file format elf32-littlearm

Sections:
Idx Name          Size      VMA       LMA       File off  Algn
  0 PrgCode       000001bc  00000000  00000000  000000b4  2**2
                  CONTENTS, ALLOC, LOAD, CODE
  1 PrgData       00000004  000001bc  000001bc  00000270  2**2
                  CONTENTS, ALLOC, LOAD, DATA
  2 DevDscr       000000b0  000001c0  000001c0  00000274  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  3 .debug_loc    00000360  00000000  00000000  00000324  2**0
                  CONTENTS, READONLY, DEBUGGING, OCTETS
  4 .debug_abbrev 0000034b  00000000  00000000  00000684  2**0
                  CONTENTS, READONLY, DEBUGGING, OCTETS
  5 .debug_info   000016d4  00000000  00000000  000009cf  2**0
                  CONTENTS, READONLY, DEBUGGING, OCTETS
  6 .debug_aranges 00000080  00000000  00000000  000020a3  2**0
                  CONTENTS, READONLY, DEBUGGING, OCTETS
  7 .debug_str    000010fc  00000000  00000000  00002123  2**0
                  CONTENTS, READONLY, DEBUGGING, OCTETS
  8 .comment      00000040  00000000  00000000  0000321f  2**0
                  CONTENTS, READONLY
  9 .ARM.attributes 00000034  00000000  00000000  0000325f  2**0
                  CONTENTS, READONLY
 10 .debug_frame  000000b4  00000000  00000000  00003294  2**2
                  CONTENTS, READONLY, DEBUGGING, OCTETS
 11 .debug_line   00000458  00000000  00000000  00003348  2**0
                  CONTENTS, READONLY, DEBUGGING, OCTETS

$ arm-none-eabi-readelf --demangle=rust -s target/thumbv6m-none-eabi/release/flash-algo
Symbol table '.symtab' contains 24 entries:
   Num:    Value  Size Type    Bind   Vis      Ndx Name
     0: 00000000     0 NOTYPE  LOCAL  DEFAULT  UND 
     1: 00000000     0 FILE    LOCAL  DEFAULT  ABS flash_algo.9d0ee[...]
     2: 00000000     0 NOTYPE  LOCAL  DEFAULT    1 $t.0
     3: 0000019d     8 FUNC    LOCAL  DEFAULT    1 core::panicking:[...]
     4: 000000d0     0 NOTYPE  LOCAL  DEFAULT    1 $d.1
     5: 000001a4     1 OBJECT  LOCAL  DEFAULT    1 flash_algo::_IS_[...]
     6: 000001b4     4 OBJECT  LOCAL  DEFAULT    1 flash_algo::_ALG[...]
     7: 000001b8     4 OBJECT  LOCAL  DEFAULT    1 flash_algo::_ALG[...]
     8: 000001ac     4 OBJECT  LOCAL  DEFAULT    1 flash_algo::_ALG[...]
     9: 000001a8     4 OBJECT  LOCAL  DEFAULT    1 flash_algo::_ALG[...]
    10: 000001b0     4 OBJECT  LOCAL  DEFAULT    1 flash_algo::_ALG[...]
    11: 00000100     0 NOTYPE  LOCAL  DEFAULT    1 $t.2
    12: 00000128     0 NOTYPE  LOCAL  DEFAULT    1 $d.3
    13: 00000134     0 NOTYPE  LOCAL  DEFAULT    1 $t.4
    14: 00000160     0 NOTYPE  LOCAL  DEFAULT    1 $d.5
    15: 00000168     0 NOTYPE  LOCAL  DEFAULT    1 $t.6
    16: 00000194     0 NOTYPE  LOCAL  DEFAULT    1 $d.7
    17: 0000019c     0 NOTYPE  LOCAL  DEFAULT    1 $t.8
    18: 00000135    52 FUNC    GLOBAL DEFAULT    1 EraseSector
    19: 000001c0   176 OBJECT  GLOBAL DEFAULT    3 FlashDevice
    20: 00000001   256 FUNC    GLOBAL DEFAULT    1 Init
    21: 000001bc     4 OBJECT  GLOBAL DEFAULT    2 PRGDATA_Start
    22: 00000169    52 FUNC    GLOBAL DEFAULT    1 ProgramPage
    23: 00000101    52 FUNC    GLOBAL DEFAULT    1 UnInit
```

**Testing with pyocd's FlashAlgo**
```console
$ cd ~/vc/FlashAlgo
$ cp ~/vc/rust/flash-algo/target/thumbv6m-none-eabi/release/flash-algo ./
$ python scripts/generate_blobs.py flash-algo
Flash Device:
  name=b''
  version=0x0
  type=5
  start=0x10000000
  size=0x1000000
  page_size=0x100
  value_empty=0xff
  prog_timeout_ms=1000
  erase_timeout_ms=2000
  sectors:
    start=0x10000000, size=0x1000

FlashAlgo $ cat py_blob.py
"""
 Flash OS Routines (Automagically Generated)
 Copyright (c) 2017-2017 ARM Limited

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
"""

flash_algo = {

    # Flash algorithm as a hex string
    'instructions':
        "f0b503af87b01546354c7c442078012807d13448784400688047334878440068"
        "80470120069005942070681e03284dd21425288818242288254e3146f7319047"
        "002840d00490288822882249891c9047002838d0039028882288314690470028"
        "31d00646288822881b49904700282ad002902888228819499047002823d00090"
        "0196288822881349904700281bd00646049ca047039880471448784401990160"
        "1348784404601348784402990160124878440099016011487844066006980599"
        "0870002000e0069807b0f0bd00f066f852450000435800005250000046430000"
        "960100009c010000980100000e010000020100000401000000010000fc000000"
        "d0b502af084c7c44207801280ad1074878440068804706487844006880470020"
        "2070d0bd0120d0bd9a000000a00000009c000000d0b502af0949794409780129"
        "0cd10f2109074018064979440c68012211031204d823a0470020d0bd0120d0bd"
        "660000005e000000d0b502af0b4609497944097801290ad10f21090740180649"
        "79440c6811461a46a0470020d0bd0120d0bdc046300000002c00000080b500af"
        "00defede00d4d4d4000000000000000000000000000000000000000000000000",

    # Relative function addresses
    'pc_init': 0x1,
    'pc_unInit': 0x101,
    'pc_program_page': 0x169,
    'pc_erase_sector': 0x135,
    'pc_eraseAll': 0xffffffff,

    # Relative region addresses and sizes
    'ro_start': 0x0,
    'ro_size': 0x1bc,
    'rw_start': 0x1bc,
    'rw_size': 0x4,
    'zi_start': 0x1c0,
    'zi_size': 0x0,

    # Flash information
    'flash_start': 0x10000000,
    'flash_size': 0x1000000,
    'page_size': 0x100,
    'sector_sizes': (
        (0x10000000, 0x1000),
    )
}
```

**Testing with probe-rs's target-gen**
```console
$ ./target/release/target-gen elf --name algo --update ~/vc/rust/rp2040/flash-algo-update/target/thumbv6m-none-eabi/release/flash-algo probe-rs/targets/RP2040.yaml
$ cat probe-rs/targets/RP2040.yaml
name: RP2040
manufacturer:
  id: 19
  cc: 9
variants:
- name: RP2040
  cores:
  - name: core0
    type: armv6m
    core_access_options: !Arm
      ap: 0
      psel: 16787751
  - name: core1
    type: armv6m
    core_access_options: !Arm
      ap: 0
      psel: 285223207
  memory_map:
  - !Ram
    range:
      start: 0x20000000
      end: 0x20042000
    cores:
    - core0
    - core1
  - !Ram
    range:
      start: 0x21000000
      end: 0x21010000
    cores:
    - core0
    - core1
  - !Ram
    range:
      start: 0x21010000
      end: 0x21020000
    cores:
    - core0
    - core1
  - !Ram
    range:
      start: 0x21020000
      end: 0x21030000
    cores:
    - core0
    - core1
  - !Ram
    range:
      start: 0x21030000
      end: 0x21040000
    cores:
    - core0
    - core1
  - !Nvm
    range:
      start: 0x10000000
      end: 0x18000000
    is_boot_memory: true
    cores:
    - core0
    - core1
  flash_algorithms:
  - algo
- name: RP2040_SELFDEBUG
  cores:
  - name: core0
    type: armv6m
    core_access_options: !Arm
      ap: 0
      psel: 0
  memory_map:
  - !Ram
    range:
      start: 0x20000000
      end: 0x20042000
    cores:
    - core0
  - !Ram
    range:
      start: 0x21000000
      end: 0x21010000
    cores:
    - core0
  - !Ram
    range:
      start: 0x21010000
      end: 0x21020000
    cores:
    - core0
  - !Ram
    range:
      start: 0x21020000
      end: 0x21030000
    cores:
    - core0
  - !Ram
    range:
      start: 0x21030000
      end: 0x21040000
    cores:
    - core0
  - !Nvm
    range:
      start: 0x10000000
      end: 0x18000000
    is_boot_memory: true
    cores:
    - core0
  flash_algorithms:
  - algo
flash_algorithms:
- name: algo
  description: algo
  default: true
  instructions: 8LUDr4ewFUY1THxEIHgBKAfRNEh4RABogEczSHhEAGiARwEgBpAFlCBwaB4DKE3SFCUoiBgkIoglTjFG9zGQRwAoQNAEkCiIIogiSYkckEcAKDjQA5AoiCKIMUaQRwAoMdAGRiiIIogbSZBHACgq0AKQKIgiiBlJkEcAKCPQAJABliiIIogTSZBHACgb0AZGBJygRwOYgEcUSHhEAZkBYBNIeEQEYBNIeEQCmQFgEkh4RACZAWARSHhEBmAGmAWZCHAAIADgBpgHsPC9APBm+FJFAABDWAAAUlAAAEZDAACWAQAAnAEAAJgBAAAOAQAAAgEAAAQBAAAAAQAA/AAAANC1Aq8ITHxEIHgBKArRB0h4RABogEcGSHhEAGiARwAgIHDQvQEg0L2aAAAAoAAAAJwAAADQtQKvCUl5RAl4ASkM0Q8hCQdAGAZJeUQMaAEiEQMSBNgjoEcAINC9ASDQvWYAAABeAAAA0LUCrwtGCUl5RAl4ASkK0Q8hCQdAGAZJeUQMaBFGGkagRwAg0L0BINC9wEYwAAAALAAAAIC1AK8A3v7eANTU1AAAAAAAAAAAAAAAAAAAAAAAAAAA
  pc_init: 0x1
  pc_uninit: 0x101
  pc_program_page: 0x169
  pc_erase_sector: 0x135
  data_section_offset: 0x1bc
  flash_properties:
    address_range:
      start: 0x10000000
      end: 0x11000000
    page_size: 0x100
    erased_byte_value: 0xff
    program_page_timeout: 1000
    erase_sector_timeout: 2000
    sectors:
    - size: 0x1000
      address: 0x10000000
  cores:
  - core0
```