### PR TITLE
Strip DeviceData from probe-rs algo output

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,9 +15,10 @@ ELF=target/thumbv6m-none-eabi/release/flash-algo
 rust-objdump --disassemble $ELF > target/disassembly.s
 rust-objdump -x $ELF > target/dump.txt
 rust-nm $ELF -n > target/nm.txt
+# printf "Algo binary size: `rust-objcopy $ELF --remove-section DeviceData -O binary - | wc -c` bytes\n"
 
 function bin {
-    rust-objcopy $ELF -O binary - | base64 $BASE64_FLAGS
+    rust-objcopy $ELF --remove-section DeviceData -O binary - | base64 $BASE64_FLAGS
 }
 
 function sym {


### PR DESCRIPTION
Since #14 we now generate DeviceData for tools that need it.
probe-rs doesn't, so strip it out when doing the objcopy step.

This brings the algo binary size back down from to 692 bytes, which is what it was previous to PR 14 (almost anyway - replacing the unused rustc arg `inline-threshold=5` with `llvm-args=--inline-threshold=5` saved us a few more bytes)

Resolves #25