### PR TITLE
flash-algorithm: add Verify support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ version = "0.1.0"
 cortex-m = "0.7.0"
 flash-algorithm = { version = "0.5.0", default-features = false, features = [
     "panic-handler",
+    "verify",
 ] }
 
 # this lets you use `cargo fix`!

--- a/build.sh
+++ b/build.sh
@@ -30,4 +30,5 @@ cat <<EOF
     pc_uninit: $(sym UnInit)
     pc_program_page: $(sym ProgramPage)
     pc_erase_sector: $(sym EraseSector)
+    pc_verify: $(sym Verify)
 EOF

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,6 +183,32 @@ impl FlashAlgorithm for RP2Algo {
         );
         Ok(())
     }
+
+    fn verify(&mut self, address: u32, size: u32, data: Option<&[u8]>) -> Result<(), ErrorCode> {
+        let Some(data) = data else {
+            return Ok(());
+        };
+        (self.funcs.flash_flush_cache)();
+        (self.funcs.flash_enter_cmd_xip)();
+        let check = unsafe { core::slice::from_raw_parts(address as *const u8, size as usize) };
+        for (offset, (check, data)) in check.iter().zip(data.iter()).enumerate() {
+            if *check != *data {
+                (self.funcs.flash_exit_xip)();
+                // Return the first address that failed.
+                return ErrorCode::new(offset as u32 + address)
+                    .map(|e| Err(e))
+                    .unwrap_or(Ok(()));
+            }
+        }
+
+        (self.funcs.flash_exit_xip)();
+
+        // Return the last address in the flash range. Any other value (including `Ok(())`)
+        // is an error.
+        ErrorCode::new(address + size)
+            .map(|e| Err(e))
+            .unwrap_or(Ok(()))
+    }
 }
 
 impl Drop for RP2Algo {


### PR DESCRIPTION
Add support for Verifying RP2040 and RP235x devices. These normally run with XIP flash disabled which means it's not possible to access the SPI flash as long as the algorithm is initialized.